### PR TITLE
Add Kitty terminal config

### DIFF
--- a/config/kitty/current-theme.conf
+++ b/config/kitty/current-theme.conf
@@ -1,0 +1,59 @@
+# Atelier Heath Dark
+# https://github.com/atelierbram/AtelierSchemes-kitty
+
+foreground #ab9bab
+background #1b181b
+selection_foreground #ab9bab
+selection_background #292329
+
+cursor #ab9bab
+cursor_text_color #1b181b
+
+url_color #bb8a35
+
+active_border_color #776977
+inactive_border_color #1b181b
+bell_border_color #a65926
+visual_bell_color none
+
+wayland_titlebar_color #292329
+macos_titlebar_color #292329
+
+active_tab_foreground #d8cad8
+active_tab_background #1b181b
+inactive_tab_foreground #ab9bab
+inactive_tab_background #292329
+tab_bar_background #292329
+tab_bar_margin_color none
+
+mark1_foreground #1b181b
+mark1_background #d8cad8
+mark2_foreground #1b181b
+mark2_background #bb8a35
+mark3_foreground #1b181b
+mark3_background #918b3b
+
+# black
+color0 #1b181b
+color8 #776977
+# red
+color1 #ca402b
+color9 #a65926
+# green
+color2 #918b3b
+color10 #292329
+# yellow
+color3 #bb8a35
+color11 #695d69
+# blue
+color4 #516aec
+color12 #9e8f9e
+# magenta
+color5 #7b59c0
+color13 #d8cad8
+# cyan
+color6 #159393
+color14 #cc33cc
+# white
+color7 #ab9bab
+color15 #f7f3f7

--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -1,0 +1,80 @@
+# Appearance
+font_family      family="JetBrains Mono"
+bold_font        auto
+italic_font      auto
+bold_italic_font auto
+font_size 12.0
+background_opacity 1.0
+background_blur 1
+cursor_shape block
+cursor_blink_interval 0
+cursor_stop_blinking_after 0
+
+# Behavior
+term xterm-kitty
+enable_audio_bell no
+linux_display_server x11
+shell_integration no-cursor
+scrollback_lines 5000
+wheel_scroll_multiplier 3.0
+mouse_hide_wait -1
+allow_remote_control yes
+listen_on unix:/tmp/mykitty
+env GLFW_SILENCE_ERRORS=1
+
+# Window
+remember_window_size  no
+initial_window_width  1200
+initial_window_height 750
+window_border_width 1.5pt
+enabled_layouts tall
+window_padding_width 0
+window_margin_width 2
+hide_window_decorations no
+
+# Tab bar
+tab_bar_edge top
+tab_bar_margin_width 10
+tab_bar_margin_height 15 0
+tab_bar_style fade
+tab_fade 0
+tab_title_template          "{fmt.bg._080808}{fmt.fg._303030}{fmt.fg.default}{fmt.bg._303030}{fmt.fg._c6c6c6} {title} {fmt.fg.default}{fmt.bg.default}{fmt.fg._303030}{fmt.fg.default}"
+active_tab_title_template   "{fmt.bg._080808}{fmt.fg._80a0ff}{fmt.fg.default}{fmt.bg._80a0ff}{fmt.fg._080808} {title} {fmt.fg.default}{fmt.bg.default}{fmt.fg._80a0ff}{fmt.fg.default}"
+active_tab_font_style normal
+inactive_tab_font_style normal
+
+# Key bindings
+map ctrl+shift+backspace change_font_size all 0
+map ctrl+shift+enter new_window
+map ctrl+shift+] next_window
+map ctrl+shift+[ previous_window
+map ctrl+shift+l next_layout
+map ctrl+alt+r goto_layout tall
+map ctrl+alt+s goto_layout stack
+map cmd+left send_text all \x01
+map cmd+right send_text all \x05
+map alt+left send_text all \x1bb
+map alt+right send_text all \x1bf
+map cmd+backspace send_text all \x15
+map alt+backspace send_text all \x17
+map cmd+f launch --type=overlay --stdin-source=@screen_scrollback /opt/homebrew/bin/fzf --no-sort --no-mouse --exact -i --tac
+map cmd+1 goto_tab 1
+map cmd+2 goto_tab 2
+map cmd+3 goto_tab 3
+map cmd+4 goto_tab 4
+map cmd+5 goto_tab 5
+map cmd+6 goto_tab 6
+map cmd+7 goto_tab 7
+map cmd+8 goto_tab 8
+map cmd+9 goto_tab 9
+map cmd+shift+t set_tab_title
+map cmd+d launch --location=vsplit --cwd=current
+map cmd+shift+d launch --location=hsplit --cwd=current
+map cmd+w close_window
+map cmd+shift+left neighboring_window left
+map cmd+shift+right neighboring_window right
+map cmd+shift+up neighboring_window up
+map cmd+shift+down neighboring_window down
+
+# Theme
+include current-theme.conf

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,8 @@ linux() {
   git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"/themes/powerlevel10k
 
   # Backup old config files and symlink new ones
-  for name in gitconfig gitignore zshrc config/terminator/config tmux.conf p10k.zsh; do
+  mkdir -p "$HOME/.config/kitty"
+  for name in gitconfig gitignore zshrc config/terminator/config config/kitty/kitty.conf config/kitty/current-theme.conf tmux.conf p10k.zsh; do
     if [ ! -d "$name" ]; then
       target="$HOME/.$name"
       backup "$target"
@@ -143,7 +144,8 @@ darwin() {
   brew install --cask font-jetbrains-mono
 
   # Backup old config files and symlink new ones
-  for name in gitconfig gitignore zshrc tmux.conf p10k.zsh; do
+  mkdir -p "$HOME/.config/kitty"
+  for name in gitconfig gitignore zshrc config/kitty/kitty.conf config/kitty/current-theme.conf tmux.conf p10k.zsh; do
     if [ ! -d "$name" ]; then
       target="$HOME/.$name"
       backup "$target"


### PR DESCRIPTION
## Summary
- Adds `config/kitty/kitty.conf` and `config/kitty/current-theme.conf` (Atelier Cave Dark theme)
- Updates `install.sh` to symlink kitty config to `~/.config/kitty/` on both Linux and macOS
