### PR TITLE
Add Zed as default git editor

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -17,6 +17,7 @@
 	autocrlf = input
 	pager = diff-so-fancy | less --tabs=4 -RFX
 	excludesFile = ~/.gitignore
+	editor = zed --wait
 
 [init]
 	defaultBranch = main


### PR DESCRIPTION
## Summary
- Sets `editor = zed --wait` in gitconfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)