### PR TITLE
Add tmux config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ linux() {
   git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"/themes/powerlevel10k
 
   # Backup old config files and symlink new ones
-  for name in gitconfig gitignore zshrc config/terminator/config p10k.zsh; do
+  for name in gitconfig gitignore zshrc config/terminator/config tmux.conf p10k.zsh; do
     if [ ! -d "$name" ]; then
       target="$HOME/.$name"
       backup "$target"
@@ -143,7 +143,7 @@ darwin() {
   brew install --cask font-jetbrains-mono
 
   # Backup old config files and symlink new ones
-  for name in gitconfig gitignore zshrc p10k.zsh; do
+  for name in gitconfig gitignore zshrc tmux.conf p10k.zsh; do
     if [ ! -d "$name" ]; then
       target="$HOME/.$name"
       backup "$target"

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,0 +1,130 @@
+# =============================================================================
+# Tmux Configuration - Zellij-like bindings
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# General Settings
+# -----------------------------------------------------------------------------
+
+set -g default-terminal "xterm-256color"
+set -ga terminal-overrides ",xterm-256color:Tc"
+set -g mouse on
+set -sg escape-time 10
+set -g history-limit 10000
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+set -g allow-rename off
+
+# -----------------------------------------------------------------------------
+# Status Bar
+# -----------------------------------------------------------------------------
+
+set -g status-position bottom
+set -g status-style 'bg=#1e1e2e fg=#cdd6f4'
+set -g status-left '#[bg=#89b4fa,fg=#1e1e2e,bold] #S #[default] '
+set -g status-left-length 30
+set -g status-right '#[fg=#6c7086] %H:%M '
+set -g window-status-format '#[fg=#6c7086] #I:#W '
+set -g window-status-current-format '#[bg=#45475a,fg=#cdd6f4,bold] #I:#W '
+
+# -----------------------------------------------------------------------------
+# Key Bindings
+# -----------------------------------------------------------------------------
+
+# Prefix is Ctrl-b (default)
+set -g prefix C-b
+
+# Alt+w - Session picker with fzf (like zellij session-manager)
+bind -n M-p display-popup -E "tmux list-sessions -F '#{session_name}' | fzf --reverse --header='Switch session' | xargs -I {} tmux switch-client -t {}"
+
+# Alt+[ / Alt+] - Previous/Next window
+bind -n M-[ previous-window
+bind -n M-] next-window
+
+# Alt+h/j/k/l - Pane navigation
+bind -n M-h select-pane -L
+bind -n M-j select-pane -D
+bind -n M-k select-pane -U
+bind -n M-l select-pane -R
+
+# Ctrl+p - Enter pane mode (like zellij)
+bind -n C-p switch-client -T pane-mode
+
+# Pane mode bindings (after Ctrl+p)
+bind -T pane-mode r split-window -h -c "#{pane_current_path}"   # split right
+bind -T pane-mode d split-window -v -c "#{pane_current_path}"   # split down
+bind -T pane-mode h select-pane -L
+bind -T pane-mode j select-pane -D
+bind -T pane-mode k select-pane -U
+bind -T pane-mode l select-pane -R
+bind -T pane-mode x kill-pane
+bind -T pane-mode z resize-pane -Z                               # toggle zoom
+bind -T pane-mode f resize-pane -Z                               # toggle fullscreen
+bind -T pane-mode n next-window
+bind -T pane-mode p previous-window
+bind -T pane-mode Escape switch-client -T root                   # cancel
+
+# Ctrl+s - Enter scroll/copy mode
+bind -n C-s copy-mode
+
+# Prefix bindings
+bind '"' split-window -v -c "#{pane_current_path}"
+bind '%' split-window -h -c "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+bind z resize-pane -Z
+bind x kill-pane
+bind d detach-client
+bind r source-file ~/.tmux.conf \; display-message "Config reloaded!"
+
+# -----------------------------------------------------------------------------
+# Copy mode (vim-style)
+# -----------------------------------------------------------------------------
+
+setw -g mode-keys vi
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode-vi Escape send-keys -X cancel
+
+# Mouse copy - auto copy to clipboard on selection
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+bind -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+
+# -----------------------------------------------------------------------------
+# Colors (Catppuccin Mocha)
+# -----------------------------------------------------------------------------
+
+set -g pane-border-style 'fg=#45475a'
+set -g pane-active-border-style 'fg=#89b4fa'
+set -g message-style 'bg=#89b4fa fg=#1e1e2e bold'
+
+# 4. Key bindings cheatsheet
+# ┌────────────────┬────────────────────────────┐
+# │    Shortcut    │           Action           │
+# ├────────────────┼────────────────────────────┤
+# │ Ctrl+P r       │ Split pane right           │
+# ├────────────────┼────────────────────────────┤
+# │ Ctrl+P d       │ Split pane down            │
+# ├────────────────┼────────────────────────────┤
+# │ Ctrl+P h/j/k/l │ Navigate panes             │
+# ├────────────────┼────────────────────────────┤
+# │ Ctrl+P x       │ Kill pane                  │
+# ├────────────────┼────────────────────────────┤
+# │ Ctrl+P z       │ Toggle zoom                │
+# ├────────────────┼────────────────────────────┤
+# │ Alt+W          │ Session picker (fzf)       │
+# ├────────────────┼────────────────────────────┤
+# │ Alt+[ / Alt+]  │ Previous/Next window       │
+# ├────────────────┼────────────────────────────┤
+# │ Alt+h/j/k/l    │ Navigate panes (no prefix) │
+# ├────────────────┼────────────────────────────┤
+# │ Ctrl+S         │ Enter scroll/copy mode     │
+# ├────────────────┼────────────────────────────┤
+# │ Ctrl+B d       │ Detach                     │
+# ├────────────────┼────────────────────────────┤
+# │ Ctrl+B r       │ Reload config              │
+# └────────────────┴────────────────────────────┘


### PR DESCRIPTION
## Summary
- Zellij-inspired keybindings (Ctrl+P pane mode, Alt+hjkl navigation, fzf session picker)
- Catppuccin Mocha theme
- Vim-style copy mode with pbcopy integration
- Symlinked as `~/.tmux.conf` on both Linux and macOS